### PR TITLE
Cleanup obsolete code from example

### DIFF
--- a/examples/inspection/plot_permutation_importance_multicollinear.py
+++ b/examples/inspection/plot_permutation_importance_multicollinear.py
@@ -66,7 +66,6 @@ import pandas as pd
 
 mdi_importances = pd.Series(clf.feature_importances_, index=X_train.columns)
 tree_importance_sorted_idx = np.argsort(clf.feature_importances_)
-tree_indices = np.arange(0, len(clf.feature_importances_)) + 0.5
 
 fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 8))
 mdi_importances.sort_values().plot.barh(ax=ax1)


### PR DESCRIPTION
Remove a line that became obsolete by https://github.com/scikit-learn/scikit-learn/commit/06b3b0e891f0df6da9f6a57bd57a655bcf816027

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs

https://github.com/scikit-learn/scikit-learn/pull/26221

#### What does this implement/fix? Explain your changes.

The mentioned PR forgot to remove the now unused `tree_indices`.
